### PR TITLE
Added Namecoin Support

### DIFF
--- a/README
+++ b/README
@@ -17,8 +17,8 @@ This generator includes the same pseudorandom key generation as bitaddress.org, 
 well as support for creating wallets using "vanity keys", passphrases ("brain wallets")
 or even rolling dice or shuffling cards.
 
-As of March 1, 2014, this generator also includes support and designs for making
-Litecoin and Dogecoin wallets.
+As of March 8, 2014, this generator also includes support and designs for making
+Dogecoin, Litecoin and Namecoin wallets.
 
 Use the "verify" tab to decrypt a BIP38 password-encrypted wallet, check the
 integrity of any private key, or even duplicate an exising wallet by scanning its

--- a/generate-wallet.html
+++ b/generate-wallet.html
@@ -92,17 +92,10 @@ function setCryptoCurrency(toThis) {
 	switch (toThis)
 	{
 	case 'Bitcoin':	
-	  window.networkVersion = 0x00;
-	  window.privateKeyPrefix = 0x80;
-	  window.WIFPrefix = '5';
-	  window.compressedWIFPrefix = '[LK]';
-	  break;
-	case 'Litecoin':
-		window.networkVersion = 0x30;
-		window.privateKeyPrefix = 0xb0;
-		window.WIFPrefix = '6';
-		window.compressedWIFPrefix = 'T';
-		document.title = 'Litecoin paper wallet generator';
+		window.networkVersion = 0x00;
+		window.privateKeyPrefix = 0x80;
+		window.WIFPrefix = '5';
+		window.compressedWIFPrefix = '[LK]';
 		break;
 	case 'Dogecoin':
 		window.networkVersion = 0x1e;
@@ -110,6 +103,20 @@ function setCryptoCurrency(toThis) {
 		window.WIFPrefix = '6';
 		window.compressedWIFPrefix = 'Q';	
 		document.title = 'Dogecoin paper wallet generator. Wow! Many coin. Such shiny.';
+		break;
+	case 'Litecoin':
+		window.networkVersion = 0x30;
+		window.privateKeyPrefix = 0xb0;
+		window.WIFPrefix = '6';
+		window.compressedWIFPrefix = 'T';
+		document.title = 'Litecoin paper wallet generator';
+		break;
+	case 'Namecoin':
+		window.networkVersion = 0x34;
+		window.privateKeyPrefix = 0xb4;
+		window.WIFPrefix = '7';
+		window.compressedWIFPrefix = 'U';
+		document.title = 'Namecoin paper wallet generator';
 		break;
 	case 'Testnet':
 		window.networkVersion = 0x6F;
@@ -136,11 +143,14 @@ var myDesign = getParameterByName('design');
 window.suppliesURL = 'https://bitcoinpaperwallet.com/?p=' + myDesign + '#purchase';
 
 switch (myDesign) {
+	case 'alt-dogecoin':
+		setCryptoCurrency('Dogecoin');
+		break;
 	case 'alt-litecoin':
 		setCryptoCurrency('Litecoin');
 		break;
-	case 'alt-dogecoin':
-		setCryptoCurrency('Dogecoin');
+	case 'alt-namecoin':
+		setCryptoCurrency('Namecoin');
 		break;
 	case 'alt-testnet':
 		setCryptoCurrency('Testnet');
@@ -5418,14 +5428,14 @@ Bitcoin.ECKey = (function () {
 		return /^[A-Fa-f0-9]{64}$/.test(key);
 	};
 
-	// 51 characters base58, bitcoin always starts with a 5, litecoin and dogecoin with a '6', testnet with a '9'
+	// 51 characters base58, bitcoin always starts with a 5, litecoin and dogecoin with a '6', namecoin with a '7' and  testnet with a '9'
 	ECKey.isWalletImportFormat = function (key) {
 		key = key.toString();
 		var matcher = new RegExp("^" + window.WIFPrefix + "[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}$", "g");
 		return (ECKey.privateKeyPrefix == window.privateKeyPrefix) ? (matcher.test(key)) : false;
 	};
 
-	// 52 characters base58, bitcoin always starts with L or K, litecoin with a T, dogecoin with a 'Q', testnet with a 'c'
+	// 52 characters base58, bitcoin always starts with L or K, dogecoin with a 'Q', litecoin with a T, namecoin with a 'U', testnet with a 'c'
 	ECKey.isCompressedWalletImportFormat = function (key) {
 		key = key.toString();
 		var matcher = new RegExp("^" + window.compressedWIFPrefix + "[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51}$", "g");
@@ -10496,8 +10506,9 @@ Bitcoin.Util = {
                           <option value="russian">Standard (Russian)</option>
                   		  <option value="spanish">Standard (Spanish)</option>
                   		  <option value="default">--- Other Cryptocurrencies ---</option>
-                  		  <option value="alt-litecoin">Litecoin</option>
                   		  <option value="alt-dogecoin">Dogecoin</option>
+                  		  <option value="alt-litecoin">Litecoin</option>
+                  		  <option value="alt-namecoin">Namecoin</option>
                   		  <option value="alt-testnet">"Testnet"</option>
                         </select>
                         </p>


### PR DESCRIPTION
The namecoin generation works as expected.

The graphics are a stand in with perhaps just a suggestion of what the color scheme should be. May I suggest you check in the PSD's so people can adjust existing designs to make other altcoin paper wallet options?

I've alphabetized the list of coins. There are lots of graphics missing, including the logo and the finished paper wallet. The front is badly photoshopped and the back is a copy of the Dogecoin one with a hue/saturation adjustment. Please change those.

Anyway, just wanting a nice-looking namecoin wallet and the code is super easy to contribute to, so I did.
