### PR TITLE
Change the brainwallet.org link to bitaddress.org

### DIFF
--- a/generate-wallet.html
+++ b/generate-wallet.html
@@ -10631,7 +10631,7 @@ Find your scissors! The final step is to cut out your wallet, fold it, and seal 
                    <br />
                    You can make a so-called "brain wallet" by supplying a VERY secure passphrase like '1852 Adobe Cloud SMASH fuzzy steamzonk'. <em>Be extremely careful doing this because a wallet generated using an insecure passphrase is virtually guaranteed to have its balance stolen!</em>.
                    <br />
-                   <br />The resulting paper wallet will still have an ordinary crypto-looking private key and public address, but you will <em>also</em> be able to retrieve your wallet contents by entering your passphrase into the 'verify' tab of this service or a similar service such as <a href="https://brainwallet.org" target="_blank">brainwallet.org</a>.<br /><br />
+                   <br />The resulting paper wallet will still have an ordinary crypto-looking private key and public address, but you will <em>also</em> be able to retrieve your wallet contents by entering your passphrase into the 'verify' tab of this service or a similar service such as the brain wallet tab on <a href="https://bitaddress.org" target="_blank">bitaddress.org</a>.<br /><br />
                     <strong>Note:</strong> supplying a brain wallet passphrase is different from BIP38-encrypting your wallet with a passphrase.
 				   <br />
                    <br />


### PR DESCRIPTION
As https://brainwallet.org is "Closed Permanently", Change the link to direct users to the brain wallet tab of https://bitaddress.org